### PR TITLE
INavigationAwareViewModel for navigation aware

### DIFF
--- a/src/Mobile/Pages/BaseContentPage.cs
+++ b/src/Mobile/Pages/BaseContentPage.cs
@@ -1,0 +1,18 @@
+﻿
+namespace Microsoft.NetConf2021.Maui.Pages;
+
+public class BaseContentPage:ContentPage
+{
+    protected override async void OnAppearing()
+    {
+        base.OnAppearing();
+        if (BindingContext is INavigationAwareViewModel)
+            await ((INavigationAwareViewModel)BindingContext).OnAppearingAsync();
+    }
+    protected override async void OnDisappearing()
+    {
+        base.OnDisappearing();
+        if (BindingContext is INavigationAwareViewModel)
+            await ((INavigationAwareViewModel)BindingContext).OnDisappearingAsync();
+    }
+}

--- a/src/Mobile/Pages/CategoriesPage.xaml
+++ b/src/Mobile/Pages/CategoriesPage.xaml
@@ -1,7 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
-<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+<pages:BaseContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:viewmodels="clr-namespace:Microsoft.NetConf2021.Maui.ViewModels"
+             xmlns:pages="clr-namespace:Microsoft.NetConf2021.Maui.Pages"
              Style="{StaticResource DetailPageStyle}"
              xmlns:res="clr-namespace:Microsoft.NetConf2021.Maui.Resources.Strings"
              x:Class="Microsoft.NetConf2021.Maui.Pages.CategoriesPage">
@@ -34,4 +35,4 @@
             </DataTemplate>
         </CollectionView.ItemTemplate>
     </CollectionView>
-</ContentPage>
+</pages:BaseContentPage>

--- a/src/Mobile/Pages/CategoriesPage.xaml.cs
+++ b/src/Mobile/Pages/CategoriesPage.xaml.cs
@@ -1,17 +1,10 @@
 ﻿namespace Microsoft.NetConf2021.Maui.Pages;
 
-public partial class CategoriesPage : ContentPage
-{
-    CategoriesViewModel vm => BindingContext as CategoriesViewModel;
+public partial class CategoriesPage : BaseContentPage
+{ 
     public CategoriesPage(CategoriesViewModel vm)
     {
+        BindingContext = vm;
         InitializeComponent();
-        BindingContext = vm;    
-    }
-
-    protected override async void OnAppearing()
-    {
-        base.OnAppearing();
-        await vm.InitializeAsync();
     }
 }

--- a/src/Mobile/Pages/DiscoverPage.xaml
+++ b/src/Mobile/Pages/DiscoverPage.xaml
@@ -1,9 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
-<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+<pages:BaseContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:res="clr-namespace:Microsoft.NetConf2021.Maui.Resources.Strings"
              Title="{x:Static res:AppResource.Home}"
              x:Name="this"
+             xmlns:pages="clr-namespace:Microsoft.NetConf2021.Maui.Pages"
              xmlns:view="clr-namespace:Microsoft.NetConf2021.Maui.Views"
              xmlns:viewmodels="clr-namespace:Microsoft.NetConf2021.Maui.ViewModels"
              BackgroundColor="{DynamicResource PageBackgroundColor}"
@@ -55,4 +56,4 @@
         </controls:Player>
 
     </Grid>
-</ContentPage>
+</pages:BaseContentPage>

--- a/src/Mobile/Pages/DiscoverPage.xaml.cs
+++ b/src/Mobile/Pages/DiscoverPage.xaml.cs
@@ -1,9 +1,7 @@
 ﻿namespace Microsoft.NetConf2021.Maui.Pages;
 
-public partial class DiscoverPage : ContentPage
+public partial class DiscoverPage : BaseContentPage
 {
-    private DiscoverViewModel viewModel => BindingContext as DiscoverViewModel;
-
     public DiscoverPage(DiscoverViewModel vm)
     {
         InitializeComponent();
@@ -12,9 +10,8 @@ public partial class DiscoverPage : ContentPage
 
     protected override async void OnAppearing()
     {
-        base.OnAppearing();
         player.OnAppearing();
-        await viewModel.InitializeAsync();
+        base.OnAppearing();
     }
 
     protected override void OnDisappearing()

--- a/src/Mobile/Pages/EpisodeDetailPage.xaml
+++ b/src/Mobile/Pages/EpisodeDetailPage.xaml
@@ -1,7 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
-<ContentPage x:Class="Microsoft.NetConf2021.Maui.Pages.EpisodeDetailPage"
+<pages:BaseContentPage x:Class="Microsoft.NetConf2021.Maui.Pages.EpisodeDetailPage"
              xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:pages="clr-namespace:Microsoft.NetConf2021.Maui.Pages"
              xmlns:viewmodels="clr-namespace:Microsoft.NetConf2021.Maui.ViewModels"
              x:DataType="viewmodels:EpisodeDetailViewModel"
              Style="{StaticResource DetailPageStyle}"
@@ -74,4 +75,4 @@
         </controls:Player>
 
     </Grid>
-</ContentPage>
+</pages:BaseContentPage>

--- a/src/Mobile/Pages/EpisodeDetailPage.xaml.cs
+++ b/src/Mobile/Pages/EpisodeDetailPage.xaml.cs
@@ -2,19 +2,16 @@
 {
     public partial class EpisodeDetailPage
     {
-        private EpisodeDetailViewModel viewModel => BindingContext as EpisodeDetailViewModel;
-
         public EpisodeDetailPage(EpisodeDetailViewModel vm)
         {
-            InitializeComponent();
             BindingContext = vm;
+            InitializeComponent();
         }
 
         protected override async void OnAppearing()
         {
-            base.OnAppearing();
             this.player.OnAppearing();
-            await viewModel.InitializeAsync();
+            base.OnAppearing();
         }
 
         protected override void OnDisappearing()

--- a/src/Mobile/Pages/ListenLaterPage.xaml
+++ b/src/Mobile/Pages/ListenLaterPage.xaml
@@ -1,8 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
-<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+<pages:BaseContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:res="clr-namespace:Microsoft.NetConf2021.Maui.Resources.Strings"
              Title="{x:Static res:AppResource.Listen_Later}"
+             xmlns:pages="clr-namespace:Microsoft.NetConf2021.Maui.Pages"
              xmlns:viewmodels="clr-namespace:Microsoft.NetConf2021.Maui.ViewModels"
              xmlns:controls="clr-namespace:Microsoft.NetConf2021.Maui.Controls"
              Style="{StaticResource MainSectionStyle}"
@@ -126,4 +127,4 @@
                              VerticalOptions="End" />
         </Grid>
     </ContentPage.Content>
-</ContentPage>
+</pages:BaseContentPage>

--- a/src/Mobile/Pages/ListenLaterPage.xaml.cs
+++ b/src/Mobile/Pages/ListenLaterPage.xaml.cs
@@ -1,9 +1,7 @@
 ﻿namespace Microsoft.NetConf2021.Maui.Pages;
 
-public partial class ListenLaterPage : ContentPage
+public partial class ListenLaterPage : BaseContentPage
 {
-    ListenLaterViewModel viewModel => BindingContext as ListenLaterViewModel;
-
     public ListenLaterPage(ListenLaterViewModel vm)
     {
         InitializeComponent();
@@ -12,9 +10,8 @@ public partial class ListenLaterPage : ContentPage
 
     protected override async void OnAppearing()
     {
-        base.OnAppearing();
         player.OnAppearing();
-        await viewModel.InitializeAsync();
+        base.OnAppearing();
     }
 
     protected override void OnDisappearing()

--- a/src/Mobile/Pages/ShowDetailPage.xaml
+++ b/src/Mobile/Pages/ShowDetailPage.xaml
@@ -1,10 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
-<ContentPage x:Class="Microsoft.NetConf2021.Maui.Pages.ShowDetailPage"
+<pages:BaseContentPage x:Class="Microsoft.NetConf2021.Maui.Pages.ShowDetailPage"
              xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:controls="clr-namespace:Microsoft.NetConf2021.Maui.Controls"
              xmlns:models="clr-namespace:Microsoft.NetConf2021.Maui.Models"
              xmlns:res="clr-namespace:Microsoft.NetConf2021.Maui.Resources.Strings"
+             xmlns:pages="clr-namespace:Microsoft.NetConf2021.Maui.Pages"
              xmlns:viewmodels="clr-namespace:Microsoft.NetConf2021.Maui.ViewModels"
              x:Name="this"
              Title="{Binding Show.Show.Title}"
@@ -141,4 +142,4 @@
                          VerticalOptions="End">
         </controls:Player>
     </Grid>
-</ContentPage>
+</pages:BaseContentPage>

--- a/src/Mobile/Pages/ShowDetailPage.xaml.cs
+++ b/src/Mobile/Pages/ShowDetailPage.xaml.cs
@@ -1,9 +1,7 @@
 ﻿namespace Microsoft.NetConf2021.Maui.Pages
 {
-    public partial class ShowDetailPage : ContentPage
+    public partial class ShowDetailPage : BaseContentPage
     {
-        private ShowDetailViewModel viewModel => BindingContext as ShowDetailViewModel;
-
         public ShowDetailPage(ShowDetailViewModel vm)
         {
             InitializeComponent();
@@ -12,9 +10,8 @@
 
         protected override async void OnAppearing()
         {
-            base.OnAppearing();
             this.player.OnAppearing();
-            await viewModel.InitializeAsync();
+            base.OnAppearing();
         }
 
         protected override void OnDisappearing()

--- a/src/Mobile/Pages/SubscriptionsPage.xaml
+++ b/src/Mobile/Pages/SubscriptionsPage.xaml
@@ -1,8 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
-<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+<pages:BaseContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:res="clr-namespace:Microsoft.NetConf2021.Maui.Resources.Strings"
              Title="{x:Static res:AppResource.Subscriptions}"
+             xmlns:pages="clr-namespace:Microsoft.NetConf2021.Maui.Pages"
              xmlns:viewmodels="clr-namespace:Microsoft.NetConf2021.Maui.ViewModels"
              xmlns:controls="clr-namespace:Microsoft.NetConf2021.Maui.Controls"
              xmlns:views="clr-namespace:Microsoft.NetConf2021.Maui.Views"
@@ -57,4 +58,4 @@
                              VerticalOptions="End"/>
         </Grid>
     </ContentPage.Content>
-</ContentPage>
+</pages:BaseContentPage>

--- a/src/Mobile/Pages/SubscriptionsPage.xaml.cs
+++ b/src/Mobile/Pages/SubscriptionsPage.xaml.cs
@@ -1,20 +1,18 @@
 ﻿namespace Microsoft.NetConf2021.Maui.Pages
 {
-    public partial class SubscriptionsPage: ContentPage
+    public partial class SubscriptionsPage: BaseContentPage
     {
-        SubscriptionsViewModel viewModel => BindingContext as SubscriptionsViewModel;
         public SubscriptionsPage(SubscriptionsViewModel vm)
         {
-            InitializeComponent();
             BindingContext = vm;
+            InitializeComponent();
         }
 
         protected override async void OnAppearing()
         {
+            player.OnAppearing();
+            subscribedPodcasts.SelectedItem = null;
             base.OnAppearing();
-            this.subscribedPodcasts.SelectedItem = null;
-            await viewModel.InitializeAsync();
-            this.player.OnAppearing();
         }
 
         protected override void OnDisappearing()

--- a/src/Mobile/ViewModels/AppBaseViewModel.cs
+++ b/src/Mobile/ViewModels/AppBaseViewModel.cs
@@ -1,0 +1,14 @@
+﻿namespace Microsoft.NetConf2021.Maui.ViewModels;
+
+public class AppBaseViewModel : BaseViewModel, INavigationAwareViewModel
+{
+    public virtual Task OnAppearingAsync()
+    {
+        return Task.CompletedTask;
+    }
+
+    public virtual Task OnDisappearingAsync()
+    {
+        return Task.CompletedTask;
+    }
+}

--- a/src/Mobile/ViewModels/CategoriesViewModel.cs
+++ b/src/Mobile/ViewModels/CategoriesViewModel.cs
@@ -1,6 +1,6 @@
 ﻿namespace Microsoft.NetConf2021.Maui.ViewModels;
 
-public class CategoriesViewModel : BaseViewModel
+public class CategoriesViewModel :AppBaseViewModel
 {
     private readonly ShowsService showsService;
 
@@ -19,15 +19,18 @@ public class CategoriesViewModel : BaseViewModel
         showsService = shows;
     }
 
-    public async Task InitializeAsync()
-    {   
-        var categories = await showsService.GetAllCategories();
-        
-        Categories = categories?.ToList();
-    }
-
     private Task SelectedCommandExecute(Category category)
     {
         return Shell.Current.GoToAsync($"{nameof(CategoryPage)}?Id={category.Id}");
     }
+
+    
+    public override async Task OnAppearingAsync()
+    {
+        await base.OnAppearingAsync();
+        var categories = await showsService.GetAllCategories();
+        Categories = categories?.ToList();
+    }
+
+
 }

--- a/src/Mobile/ViewModels/DiscoverViewModel.cs
+++ b/src/Mobile/ViewModels/DiscoverViewModel.cs
@@ -2,7 +2,7 @@
 
 namespace Microsoft.NetConf2021.Maui.ViewModels;
 
-public class DiscoverViewModel : BaseViewModel
+public class DiscoverViewModel : AppBaseViewModel
 {
     private readonly ShowsService showsService;
     private readonly SubscriptionsService subscriptionsService;
@@ -42,10 +42,6 @@ public class DiscoverViewModel : BaseViewModel
         categoriesVM = categories;
     }
 
-    internal async Task InitializeAsync()
-    {
-        await FetchAsync();
-    }
 
     private async Task FetchAsync()
     {
@@ -61,7 +57,7 @@ public class DiscoverViewModel : BaseViewModel
             return;
         }
 
-        await CategoriesVM.InitializeAsync();
+        await CategoriesVM.OnAppearingAsync();
         shows = await ConvertToViewModels(podcastsModels);
         UpdatePodcasts(shows);
     }
@@ -112,5 +108,11 @@ public class DiscoverViewModel : BaseViewModel
     private Task SeeAllCategoriesCommandExecute()
     {
         return Shell.Current.GoToAsync($"{nameof(CategoriesPage)}");
+    }
+
+    public override async Task OnAppearingAsync()
+    {
+        await base.OnAppearingAsync();
+        await FetchAsync();
     }
 }

--- a/src/Mobile/ViewModels/EpisodeDetailViewModel.cs
+++ b/src/Mobile/ViewModels/EpisodeDetailViewModel.cs
@@ -4,7 +4,7 @@ namespace Microsoft.NetConf2021.Maui.ViewModels
 {
     [QueryProperty(nameof(Id), nameof(Id))]
     [QueryProperty(nameof(ShowId), nameof(ShowId))]
-    public class EpisodeDetailViewModel : BaseViewModel
+    public class EpisodeDetailViewModel : AppBaseViewModel
     {
         public string Id { get; set; }
         public string ShowId { get; set; }
@@ -64,8 +64,9 @@ namespace Microsoft.NetConf2021.Maui.ViewModels
             ListenLaterCommand = new AsyncCommand(ListenLaterCommandExecuteAsync);
         }
 
-        internal async Task InitializeAsync()
+        public override async Task OnAppearingAsync()
         {
+            await base.OnAppearingAsync();
             if (Episode != null)
                 return;
 

--- a/src/Mobile/ViewModels/INavigationAwareViewModel.cs
+++ b/src/Mobile/ViewModels/INavigationAwareViewModel.cs
@@ -1,0 +1,7 @@
+﻿namespace Microsoft.NetConf2021.Maui.ViewModels;
+
+interface INavigationAwareViewModel
+{
+    Task OnAppearingAsync();
+    Task OnDisappearingAsync();
+}

--- a/src/Mobile/ViewModels/ListenLaterViewModel.cs
+++ b/src/Mobile/ViewModels/ListenLaterViewModel.cs
@@ -1,6 +1,6 @@
 ﻿namespace Microsoft.NetConf2021.Maui.ViewModels;
 
-public class ListenLaterViewModel : BaseViewModel
+public class ListenLaterViewModel : AppBaseViewModel
 {
     public bool HasData => Episodes?.Any() ?? false;
     public bool HasNoData => !HasData;
@@ -25,8 +25,9 @@ public class ListenLaterViewModel : BaseViewModel
         Episodes = new ObservableCollection<EpisodeViewModel>();
     }
 
-    internal async Task InitializeAsync()
+    public override async Task OnAppearingAsync()
     {
+        await base.OnAppearingAsync();
         var episodes = listenLaterService.GetEpisodes();
         Episodes.Clear();
         foreach (var episode in episodes)

--- a/src/Mobile/ViewModels/ShowDetailViewModel.cs
+++ b/src/Mobile/ViewModels/ShowDetailViewModel.cs
@@ -3,7 +3,7 @@
 namespace Microsoft.NetConf2021.Maui.ViewModels
 {
     [QueryProperty(nameof(Id), nameof(Id))]
-    public class ShowDetailViewModel : BaseViewModel
+    public class ShowDetailViewModel : AppBaseViewModel
     {
         public string Id { get; set; }
         private Guid showId;
@@ -79,9 +79,9 @@ namespace Microsoft.NetConf2021.Maui.ViewModels
                 OnPropertyChanged(nameof(Show));
             });
         }
-
-        internal async Task InitializeAsync()
+        public override async Task OnAppearingAsync()
         {
+            await base.OnAppearingAsync();
             if (Show != null)
                 return;
 

--- a/src/Mobile/ViewModels/SubscriptionsViewModel.cs
+++ b/src/Mobile/ViewModels/SubscriptionsViewModel.cs
@@ -1,6 +1,6 @@
 ﻿namespace Microsoft.NetConf2021.Maui.ViewModels;
 
-public class SubscriptionsViewModel : BaseViewModel
+public class SubscriptionsViewModel : AppBaseViewModel
 {
     public bool HasData => SubscribedShows?.Any() ?? false;
     public bool HasNoData => !HasData;
@@ -36,8 +36,9 @@ public class SubscriptionsViewModel : BaseViewModel
         return Shell.Current.GoToAsync($"{nameof(DiscoverPage)}");
     }
 
-    public async Task InitializeAsync()
+    public override async Task OnAppearingAsync()
     {
+        await base.OnAppearingAsync();
         var podcasts = subscriptionsService.GetSubscribedShows();
 
         SubscribedShows.Clear();


### PR DESCRIPTION
Seeing that there are a lot of InitializeAsync inside the pages and they all follow the same pattern I have created a new interface INavigationAwareViewModel, a new BaseViewModel(that implements the interface) and a new BaseContentPage that automatically will call the OnAppearing and OnDisapperaing on the associate ViewModel if it implements the interface.

I only changed the base class for the pages and the viewmodels that use the interface but it would be cleaner to use it in all the pages and all the viewmodels.

Hope this pull request make sense
