### PR TITLE
Support Shell DI changes in .NET MAUI P14

### DIFF
--- a/src/Mobile/MauiProgram.cs
+++ b/src/Mobile/MauiProgram.cs
@@ -13,6 +13,7 @@ public static class MauiProgram
             .UseMauiApp<App>()
             .ConfigureEssentials()
             .ConfigureServices()
+            .ConfigurePages()
             .ConfigureViewModels()
             .ConfigureFonts(fonts =>
             {

--- a/src/Mobile/Pages/PagesExtensions.cs
+++ b/src/Mobile/Pages/PagesExtensions.cs
@@ -1,0 +1,16 @@
+﻿namespace Microsoft.NetConf2021.Maui.Pages
+{
+    public static class PagesExtensions
+    {
+        public static MauiAppBuilder ConfigurePages(this MauiAppBuilder builder)
+        {
+            builder.Services.AddSingleton<DiscoverPage>();
+            builder.Services.AddSingleton<SubscriptionsPage>();
+            builder.Services.AddSingleton<ListenLaterPage>();
+            builder.Services.AddSingleton<ListenTogetherPage>();
+            builder.Services.AddSingleton<SettingsPage>();
+
+            return builder;
+        }
+    }
+}

--- a/src/Mobile/Pages/PagesExtensions.cs
+++ b/src/Mobile/Pages/PagesExtensions.cs
@@ -1,16 +1,15 @@
-﻿namespace Microsoft.NetConf2021.Maui.Pages
-{
-    public static class PagesExtensions
-    {
-        public static MauiAppBuilder ConfigurePages(this MauiAppBuilder builder)
-        {
-            builder.Services.AddSingleton<DiscoverPage>();
-            builder.Services.AddSingleton<SubscriptionsPage>();
-            builder.Services.AddSingleton<ListenLaterPage>();
-            builder.Services.AddSingleton<ListenTogetherPage>();
-            builder.Services.AddSingleton<SettingsPage>();
+namespace Microsoft.NetConf2021.Maui.Pages;
 
-            return builder;
-        }
+public static class PagesExtensions
+{
+    public static MauiAppBuilder ConfigurePages(this MauiAppBuilder builder)
+    {
+        builder.Services.AddSingleton<DiscoverPage>();
+        builder.Services.AddSingleton<SubscriptionsPage>();
+        builder.Services.AddSingleton<ListenLaterPage>();
+        builder.Services.AddSingleton<ListenTogetherPage>();
+        builder.Services.AddSingleton<SettingsPage>();
+
+        return builder;
     }
 }


### PR DESCRIPTION
There are (potentially) breaking Shell DI changes coming in .NET MAUI Preview 14.
If you want dependency injection to work with Shell pages, you need to register the page classes as well as their injected dependencies. Otherwise, you'll have to provide a parameterless constructor for any pages you don't register with the IoC container.
This PR has backwards-compatible changes that should prevent any problems once upgrading .NET MAUI to P14 and later.