### PR TITLE
Remove Microsoft.Extensions.Http from dotnet-podcasts

### DIFF
--- a/src/Mobile/Microsoft.NetConf2021.Maui.csproj
+++ b/src/Mobile/Microsoft.NetConf2021.Maui.csproj
@@ -53,7 +53,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Http" Version="6.0.0" />
     <PackageReference Include="MonkeyCache.FileStore" Version="1.5.2" />
     <PackageReference Include="Refractored.MvvmHelpers" Version="1.6.2" />
   </ItemGroup>

--- a/src/Mobile/Services/ServicesExtensions.cs
+++ b/src/Mobile/Services/ServicesExtensions.cs
@@ -8,10 +8,7 @@ public static class ServicesExtensions
     {
         builder.Services.AddBlazorWebView();
         builder.Services.AddSingleton<SubscriptionsService>();
-        builder.Services.AddHttpClient<ShowsService>(client => 
-        {
-            client.BaseAddress = new Uri(Config.APIUrl);
-        });
+        builder.Services.AddSingleton<ShowsService>();
         builder.Services.AddSingleton<ListenLaterService>();
 #if WINDOWS
         builder.Services.TryAddSingleton<IAudioService, Platforms.Windows.AudioService>();

--- a/src/Mobile/Services/ShowsService.cs
+++ b/src/Mobile/Services/ShowsService.cs
@@ -7,12 +7,11 @@ namespace Microsoft.NetConf2021.Maui.Services;
 
 public class ShowsService
 {
-    private readonly HttpClient httpClient;
+    private readonly static HttpClient s_httpClient = new HttpClient() { BaseAddress = new Uri(Config.APIUrl) };
     private readonly ListenLaterService listenLaterService;
 
-    public ShowsService(HttpClient httpClient, ListenLaterService listenLaterService)
+    public ShowsService(ListenLaterService listenLaterService)
     {
-        this.httpClient = httpClient;
         this.listenLaterService = listenLaterService;
     }
 
@@ -89,7 +88,7 @@ public class ShowsService
         {
             if (string.IsNullOrWhiteSpace(json))
             {
-                var response = await httpClient.GetAsync(path);
+                var response = await s_httpClient.GetAsync(path);
                 if (response.IsSuccessStatusCode)
                 {
                     responseData = await response.Content.ReadFromJsonAsync<T>();

--- a/src/Mobile/Services/ShowsService.cs
+++ b/src/Mobile/Services/ShowsService.cs
@@ -7,11 +7,12 @@ namespace Microsoft.NetConf2021.Maui.Services;
 
 public class ShowsService
 {
-    private readonly static HttpClient s_httpClient = new HttpClient() { BaseAddress = new Uri(Config.APIUrl) };
+    private readonly HttpClient httpClient;
     private readonly ListenLaterService listenLaterService;
 
     public ShowsService(ListenLaterService listenLaterService)
     {
+        this.httpClient = new HttpClient() { BaseAddress = new Uri(Config.APIUrl) };
         this.listenLaterService = listenLaterService;
     }
 
@@ -88,7 +89,7 @@ public class ShowsService
         {
             if (string.IsNullOrWhiteSpace(json))
             {
-                var response = await s_httpClient.GetAsync(path);
+                var response = await httpClient.GetAsync(path);
                 if (response.IsSuccessStatusCode)
                 {
                     responseData = await response.Content.ReadFromJsonAsync<T>();


### PR DESCRIPTION
See https://github.com/dotnet/runtime/issues/66863 for reasoning. Using Microsoft.Extensions.Http is too heavy-weight for mobile usages, and doesn't provide any real value in this situation.

cc @jamesmontemagno @jonathanpeppers 