### PR TITLE
Rename OSAppTheme to AppTheme.

### DIFF
--- a/src/Mobile/Blazor/ListenTogetherComponent.razor
+++ b/src/Mobile/Blazor/ListenTogetherComponent.razor
@@ -100,7 +100,7 @@
 
 	private async Task UpdateWebThemeAsync()
 	{
-		var darkModeIsActive = Settings.Theme == OSAppTheme.Dark;
+		var darkModeIsActive = Settings.Theme == AppTheme.Dark;
 		await ThemeInterop.SetTheme(darkModeIsActive ? Theme.Dark : Theme.Light);
 
 	}

--- a/src/Mobile/Helpers/Settings.cs
+++ b/src/Mobile/Helpers/Settings.cs
@@ -2,11 +2,11 @@
 
 public static class Settings
 {
-    const OSAppTheme theme = OSAppTheme.Light;
+    const AppTheme theme = AppTheme.Light;
 
-    public static OSAppTheme Theme
+    public static AppTheme Theme
     {
-        get => Enum.Parse<OSAppTheme>(Preferences.Get(nameof(Theme), Enum.GetName(theme)));
+        get => Enum.Parse<AppTheme>(Preferences.Get(nameof(Theme), Enum.GetName(theme)));
         set => Preferences.Set(nameof(Theme), value.ToString());
     }
     

--- a/src/Mobile/Helpers/TheTheme.cs
+++ b/src/Mobile/Helpers/TheTheme.cs
@@ -7,11 +7,11 @@ public static class TheTheme
         switch (Settings.Theme)
         {
             default:
-            case OSAppTheme.Light:
-                App.Current.UserAppTheme = OSAppTheme.Light;
+            case AppTheme.Light:
+                App.Current.UserAppTheme = AppTheme.Light;
                 break;
-            case OSAppTheme.Dark:
-                App.Current.UserAppTheme = OSAppTheme.Dark;
+            case AppTheme.Dark:
+                App.Current.UserAppTheme = AppTheme.Dark;
                 break;
 
         }

--- a/src/Mobile/ViewModels/SettingsViewModel.cs
+++ b/src/Mobile/ViewModels/SettingsViewModel.cs
@@ -33,15 +33,15 @@ public class SettingsViewModel : BaseViewModel
 
     public SettingsViewModel()
     {
-        isDarkModeEnabled = Settings.Theme == OSAppTheme.Dark;
+        isDarkModeEnabled = Settings.Theme == AppTheme.Dark;
         isWifiOnlyEnabled = Settings.IsWifiOnlyEnabled;
     }
 
     private void ChangeUserAppTheme(bool activateDarkMode)
     {
         Settings.Theme = activateDarkMode 
-            ? OSAppTheme.Dark
-            : OSAppTheme.Light;
+            ? AppTheme.Dark
+            : AppTheme.Light;
 
         TheTheme.SetTheme();
     }


### PR DESCRIPTION
OSAppTheme has been renamed to AppTheme, this ensures that renaming doesn't file builds.