### PR TITLE
[mobile] install dotnet/maui/main on maui/perf

### DIFF
--- a/.github/workflows/podcast-mobile.yml
+++ b/.github/workflows/podcast-mobile.yml
@@ -27,7 +27,11 @@ jobs:
           include-prerelease: true
 
       - name: install MAUI workload
-        run: dotnet workload install maui
+        shell: pwsh
+        run: |
+          $ProgressPreference = 'SilentlyContinue'
+          Invoke-WebRequest https://raw.githubusercontent.com/dotnet/maui/main/NuGet.config -OutFile NuGet.config
+          dotnet workload install maui --from-rollback-file https://aka.ms/dotnet/maui/main.json --configfile NuGet.config
 
       - name: build Microsoft.NetConf2021.Maui.csproj
         run: dotnet build src/Mobile/Microsoft.NetConf2021.Maui.csproj -bl:mobile.binlog

--- a/.github/workflows/podcast-mobile.yml
+++ b/.github/workflows/podcast-mobile.yml
@@ -21,20 +21,23 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: install .NET 6
-        uses: actions/setup-dotnet@v1
-        with:
-          dotnet-version: 6.0.x
-          include-prerelease: true
+        shell: pwsh
+        run: |
+          $ProgressPreference = 'SilentlyContinue'
+          Invoke-WebRequest https://dot.net/v1/dotnet-install.ps1 -OutFile dotnet-install.ps1
+          .\dotnet-install.ps1 -Channel 6.0.3xx -Quality daily -InstallDir .
 
       - name: install MAUI workload
         shell: pwsh
         run: |
           $ProgressPreference = 'SilentlyContinue'
           Invoke-WebRequest https://raw.githubusercontent.com/dotnet/maui/main/NuGet.config -OutFile NuGet.config
-          dotnet workload install maui --from-rollback-file https://aka.ms/dotnet/maui/main.json --configfile NuGet.config
+          & .\dotnet workload install maui --from-rollback-file https://aka.ms/dotnet/maui/main.json --configfile NuGet.config
 
       - name: build Microsoft.NetConf2021.Maui.csproj
-        run: dotnet build src/Mobile/Microsoft.NetConf2021.Maui.csproj -bl:mobile.binlog
+        shell: pwsh
+        run: |
+          & .\dotnet build src/Mobile/Microsoft.NetConf2021.Maui.csproj -bl:mobile.binlog
 
       - name: archive logs
         if: always()

--- a/src/Mobile/MauiProgram.cs
+++ b/src/Mobile/MauiProgram.cs
@@ -25,6 +25,7 @@ public static class MauiProgram
 
         Barrel.ApplicationId = "dotnetpodcasts";
 
+        builder.Services.AddMauiBlazorWebView();
         builder.Services.AddTransient<CategoriesPage>();
         builder.Services.AddTransient<CategoryPage>();
         builder.Services.AddTransient<DiscoverPage>();

--- a/src/Mobile/MauiProgram.cs
+++ b/src/Mobile/MauiProgram.cs
@@ -9,7 +9,6 @@ public static class MauiProgram
     {
         var builder = MauiApp.CreateBuilder();
         builder
-            .RegisterBlazorMauiWebView()
             .UseMauiApp<App>()
             .ConfigureEssentials()
             .ConfigureServices()

--- a/src/Mobile/Resources/Styles/DefaultTheme.xaml
+++ b/src/Mobile/Resources/Styles/DefaultTheme.xaml
@@ -55,7 +55,7 @@
 
     <Style x:Key="DetailPageStyle" BasedOn="{StaticResource MainSectionStyle}" TargetType="Page">
         <Setter Property="Shell.NavBarIsVisible"
-                    Value="{OnPlatform Android=true, iOS=true, UWP=false}" />
+                    Value="{OnPlatform Android=true, iOS=true, UWP=false, MacCatalyst=false}" />
     </Style>
 
     <Style TargetType="Page"


### PR DESCRIPTION
We have the maui/perf branch tracking dotnet/maui/main, so we need to actually install different versions of the workloads.

dotnet-podcasts/main is tracking the latest release, .NET MAUI Preview 14 at this time.