### PR TITLE
Run GetShowsAsync in the background

### DIFF
--- a/src/Mobile/ViewModels/DiscoverViewModel.cs
+++ b/src/Mobile/ViewModels/DiscoverViewModel.cs
@@ -49,7 +49,9 @@ public class DiscoverViewModel : BaseViewModel
 
     private async Task FetchAsync()
     {
-        var podcastsModels = await showsService.GetShowsAsync();
+        // run GetShowsAsync in the background, so things get initialized in the background
+        // like checking the cache and the web request
+        var podcastsModels = await Task.Run(() => showsService.GetShowsAsync());
 
         if (podcastsModels == null)
         {

--- a/src/Mobile/ViewModels/DiscoverViewModel.cs
+++ b/src/Mobile/ViewModels/DiscoverViewModel.cs
@@ -49,9 +49,7 @@ public class DiscoverViewModel : BaseViewModel
 
     private async Task FetchAsync()
     {
-        // run GetShowsAsync in the background, so things get initialized in the background
-        // like checking the cache and the web request
-        var podcastsModels = await Task.Run(() => showsService.GetShowsAsync());
+        var podcastsModels = await showsService.GetShowsAsync();
 
         if (podcastsModels == null)
         {


### PR DESCRIPTION
This allows for faster startup because initializing and checking the cache doesn't block the UI thread.

On my Pixel5a, launching the app 10 times and averaging startup times with this change:

### Before
Average(ms): 843.7
Average(ms): 847.8

### After
Average(ms): 817.2
Average(ms): 812.8