### PR TITLE
Use System.Text.Json instead of Newtonsoft.

### DIFF
--- a/src/Mobile/Microsoft.NetConf2021.Maui.csproj
+++ b/src/Mobile/Microsoft.NetConf2021.Maui.csproj
@@ -53,7 +53,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="MonkeyCache.FileStore" Version="1.5.2" />
+    <PackageReference Include="MonkeyCache.FileStore" Version="2.0.0-beta" />
     <PackageReference Include="Refractored.MvvmHelpers" Version="1.6.2" />
   </ItemGroup>
 

--- a/src/Mobile/Services/ShowsService.cs
+++ b/src/Mobile/Services/ShowsService.cs
@@ -1,7 +1,7 @@
 ﻿using System.Net.Http.Json;
+using System.Text.Json;
 using Microsoft.NetConf2021.Maui.Models.Responses;
 using MonkeyCache.FileStore;
-using Newtonsoft.Json;
 
 namespace Microsoft.NetConf2021.Maui.Services;
 
@@ -116,7 +116,7 @@ public class ShowsService
             }
             else
             {
-                responseData = JsonConvert.DeserializeObject<T>(json);
+                responseData = JsonSerializer.Deserialize<T>(json);
             }
 
             if (responseData != null)


### PR DESCRIPTION
This reduces the size of the app because Newtonsoft and all the code it roots (XML, System.Data.Common) can now be trimmed.

Porting #58 to main.