### PR TITLE
Fix CI build

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <fallbackPackageFolders>
+    <clear />
+  </fallbackPackageFolders>
+  <packageSources>
+    <clear />
+    <!-- Don't add any private feeds. nuget.org should be the only required feed for the main branch. -->
+    <add key="nuget" value="https://api.nuget.org/v3/index.json" />
+  </packageSources>
+  <disabledPackageSources>
+    <clear />
+  </disabledPackageSources>
+</configuration>


### PR DESCRIPTION
Ensure main's CI build only uses nuget.org feed. Since main represents the latest released version, only public packages on nuget.org should be needed.

See https://docs.microsoft.com/en-us/nuget/concepts/security-best-practices#nuget-feeds