### PR TITLE
Move workload install NuGet.config file so it doesn't overwrite repo's NuGet.config

### DIFF
--- a/.github/workflows/podcast-mobile.yml
+++ b/.github/workflows/podcast-mobile.yml
@@ -31,8 +31,8 @@ jobs:
         shell: pwsh
         run: |
           $ProgressPreference = 'SilentlyContinue'
-          Invoke-WebRequest https://raw.githubusercontent.com/dotnet/maui/main/NuGet.config -OutFile NuGet.config
-          & .\dotnet workload install maui --from-rollback-file https://aka.ms/dotnet/maui/main.json --configfile NuGet.config
+          Invoke-WebRequest https://raw.githubusercontent.com/dotnet/maui/main/NuGet.config -OutFile maui-main-NuGet.config
+          & .\dotnet workload install maui --from-rollback-file https://aka.ms/dotnet/maui/main.json --configfile maui-main-NuGet.config
 
       - name: build Microsoft.NetConf2021.Maui.csproj
         shell: pwsh


### PR DESCRIPTION
Since #66 added a NuGet.config to the root of the repo, the GH action is clobbering this file. So when we run in CI we aren't using the same NuGet.config file as a "normal" dev would use.

Moving the NuGet.config file used by `workload install` to avoid this conflict.