### PR TITLE
Dynamic podcast grouping

### DIFF
--- a/src/Mobile/Models/Responses/ShowResponse.cs
+++ b/src/Mobile/Models/Responses/ShowResponse.cs
@@ -19,6 +19,8 @@
         public string Email { get; set; }
 
         public string Language { get; set; }
+
+        public bool IsFeatured { get; set; }
         
         public CategoryResponse[] Categories { get; set; }
 

--- a/src/Mobile/Models/Show.cs
+++ b/src/Mobile/Models/Show.cs
@@ -24,6 +24,7 @@ public class Show : ObservableObject
         Updated = response.Updated;
         Episodes = response.Episodes?.Select(resp => new Episode(resp, listenLaterService));
         Categories = response.Categories?.Select(resp => new Category(resp));
+        IsFeatured = response.IsFeatured;
     }
 
     public Guid Id { get; set; }
@@ -41,4 +42,6 @@ public class Show : ObservableObject
     public IEnumerable<Episode> Episodes { get; set; }
 
     public IEnumerable<Category> Categories { get; set; }
+
+    public bool IsFeatured { get; set; }
 }


### PR DESCRIPTION
We now group the podcasts as the web project does. 
Now it doesn't show the category headers if the list is empty in searches.