### PR TITLE
fix grid size

### DIFF
--- a/src/Mobile/Controls/HeaderControl.xaml
+++ b/src/Mobile/Controls/HeaderControl.xaml
@@ -7,7 +7,8 @@
         <ContentView>
             <OnPlatform x:TypeArguments="View">
                 <On Platform="UWP, macOS">
-                    <Grid RowDefinitions="*, auto">
+                    <Grid 
+                        RowDefinitions="auto, auto">
                         <SearchBar x:Name="searchBar"
                                    HorizontalOptions="Start"
                                    WidthRequest="460"
@@ -30,7 +31,7 @@
                     </Grid>
                 </On>
                 <On Platform="Android,iOS">
-                    <Grid ColumnDefinitions="*,*"
+                    <Grid ColumnDefinitions="auto, *"
                           Margin="16,12">
                         <Image Source="{AppThemeBinding Light=logo_header_horizontal.png,Dark=logo_color_horizontal_darkmode.png}"
                                HeightRequest="34"

--- a/src/Mobile/Pages/ShowDetailPage.xaml
+++ b/src/Mobile/Pages/ShowDetailPage.xaml
@@ -87,7 +87,7 @@
             </CollectionView.ItemTemplate>
             <CollectionView.Header>
                 <Grid Padding="{OnIdiom Default=30, Phone=22}"
-                      ColumnDefinitions="auto, auto"
+                      ColumnDefinitions="auto, *"
                       ColumnSpacing="{OnIdiom Default=22, Phone=10}"
                       RowDefinitions="auto,auto,auto,auto,auto"
                       RowSpacing="{OnIdiom Default=10, Phone=6}">


### PR DESCRIPTION
With .NET MAUI RC2. Some grid do not look good.

Screenshots:
Before:
![image](https://user-images.githubusercontent.com/21368617/165483547-bb835f15-9294-477b-8518-de7961a1e1e9.png)

After (with fix):
![image](https://user-images.githubusercontent.com/21368617/165483657-2b18d187-a164-4a23-82a5-e03d8c5eab6a.png)
