### PR TITLE
fix ios lauch

### DIFF
--- a/src/Mobile/Controls/Player.xaml
+++ b/src/Mobile/Controls/Player.xaml
@@ -8,13 +8,6 @@
              xmlns:local="clr-namespace:Microsoft.NetConf2021.Maui.Controls"
              xmlns:res="clr-namespace:Microsoft.NetConf2021.Maui.Resources.Strings"
              x:DataType="local:Player">
-    <ContentView.HeightRequest>
-        <OnPlatform x:TypeArguments="x:Double">
-            <On Platform="Android,iOS">70</On>
-            <On Platform="UWP,macOS">90</On>
-        </OnPlatform>
-    </ContentView.HeightRequest>
-
     <ContentView.Content>
         <OnPlatform x:TypeArguments="View">
             <On Platform="Android,iOS">

--- a/src/Mobile/Controls/Player.xaml.cs
+++ b/src/Mobile/Controls/Player.xaml.cs
@@ -9,6 +9,12 @@ public partial class Player : ContentView
         InitializeComponent();
         AutomationProperties.SetIsInAccessibleTree(this, true);
         this.IsVisible = false;
+
+#if WINDOWS || MACCATALYST
+        this.HeightRequest = 90;
+#elif ANDROID || IOS
+        this.HeightRequest = 70;
+#endif
     }
 
     protected override void OnHandlerChanged()


### PR DESCRIPTION
We have a crash on IOS when app is launched.
Adding the height by code avoids this bug.
<img width="964" alt="MicrosoftTeams-image (7)" src="https://user-images.githubusercontent.com/21368617/165744777-6055e259-2138-4fb2-9a96-57c15c53f1e5.png">

