### PR TITLE
workaround on macos - Issue #90 

### DIFF
--- a/src/Mobile/Pages/DiscoverPage.xaml
+++ b/src/Mobile/Pages/DiscoverPage.xaml
@@ -30,10 +30,17 @@
                         SelectionMode="None"
                         IsGrouped="True">
             <CollectionView.ItemsLayout>
-                <GridItemsLayout Orientation="Vertical"
+                <OnPlatform x:TypeArguments="ItemsLayout">
+                    <!-- On MacOS does not load any items with IsGrouped=True + GridItemsLayout -->
+                    <!-- https://github.com/dotnet/maui/issues/6848 -->
+                    <!-- Temporary workaround: On MacOS, not to use GridItemLayout-->
+                    <On Platform="Android,iOS,UWP">
+                        <GridItemsLayout Orientation="Vertical"
                                  Span="{OnIdiom Phone=2, Tablet=3, Desktop=3, Default=3}"
                                  HorizontalItemSpacing="5"
                                  VerticalItemSpacing="5" />
+                    </On>
+                </OnPlatform>
             </CollectionView.ItemsLayout>
             <CollectionView.ItemTemplate>
                 <DataTemplate>


### PR DESCRIPTION
This PR is a temporary workaround: [MacOS - CollectionView with grouping + GridItemsLayout does not load.](https://github.com/dotnet/maui/issues/6848)
https://github.com/dotnet/maui/issues/6848

In the future we will use Flexlayout but now we are in this discussion here: https://github.com/microsoft/dotnet-podcasts/pull/90
Merge only if necessary.

@jamesmontemagno @maddymontaquila 