### PR TITLE
Show nav bar on macos

### DIFF
--- a/src/Mobile/Resources/Styles/DefaultTheme.xaml
+++ b/src/Mobile/Resources/Styles/DefaultTheme.xaml
@@ -55,7 +55,7 @@
 
     <Style x:Key="DetailPageStyle" BasedOn="{StaticResource MainSectionStyle}" TargetType="Page">
         <Setter Property="Shell.NavBarIsVisible"
-                    Value="{OnPlatform Android=true, iOS=true, UWP=false, MacCatalyst=false}" />
+                    Value="{OnPlatform Android=true, iOS=true, UWP=false, MacCatalyst=true}" />
     </Style>
 
     <Style TargetType="Page"


### PR DESCRIPTION
We need to show the navigation bar in macOS so that the back button appears.
Now, we can navigate to back.