### PR TITLE
Replace macos by MacCatalyst

### DIFF
--- a/src/Mobile/Controls/HeaderControl.xaml
+++ b/src/Mobile/Controls/HeaderControl.xaml
@@ -7,7 +7,7 @@
     <ContentView.Content>
         <ContentView>
             <OnPlatform x:TypeArguments="View">
-                <On Platform="UWP, macOS">
+                <On Platform="UWP, MacCatalyst">
                     <Grid 
                         RowDefinitions="auto, auto">
                         <SearchBar x:Name="searchBar"

--- a/src/Mobile/Controls/Player.xaml
+++ b/src/Mobile/Controls/Player.xaml
@@ -36,7 +36,7 @@
 
                 </Grid>
             </On>
-            <On Platform="UWP, macOS">
+            <On Platform="UWP, MacCatalyst">
                 <Grid ColumnDefinitions="auto, *, auto">
                     <Grid ColumnDefinitions="auto, auto"
                           RowDefinitions="auto,auto"

--- a/src/Mobile/Pages/ShowDetailPage.xaml
+++ b/src/Mobile/Pages/ShowDetailPage.xaml
@@ -72,8 +72,8 @@
                                      WidthRequest="28">
                             <ImageButton.IsVisible>
                                 <OnPlatform x:TypeArguments="x:Boolean">
-                                    <On Platform="Android,iOS">false</On>
-                                    <On Platform="UWP,macOS">true</On>
+                                    <On Platform="Android, iOS">false</On>
+                                    <On Platform="UWP, MacCatalyst">true</On>
                                 </OnPlatform>
                             </ImageButton.IsVisible>
                             <ImageButton.Triggers>


### PR DESCRIPTION
Some views were not visible because a label was used that does not exist. This has been replaced with the correct tag.
OLD TAG: macos
NEW TAG: macCatalyst