### PR TITLE
fixed audio over all platforms

### DIFF
--- a/src/Web/Pages/Shared/Player/Audio.razor
+++ b/src/Web/Pages/Shared/Player/Audio.razor
@@ -7,7 +7,6 @@
        oncustomdurationchange="@OnDurationChange"
        oncustomtimeupdate="@OnTimeUpdate"
        onplaybackratechange="@OnPlaybackRateChange"
-       oncanplay="@OnCanPlay"
        onplay="@OnPlay"
        onpause="@OnPause" />
 
@@ -15,7 +14,6 @@
     ElementReference AudioElementRef;
 
     private string? url;
-    private bool loadingUrl;
 
     protected override void OnInitialized()
     {
@@ -66,15 +64,6 @@
         PlayerService.PlaybackRate = args.PlaybackRate;
     }
 
-    private async Task OnCanPlay(EventArgs args)
-    {
-        loadingUrl = false;
-        if (PlayerService.IsPlaying)
-        {
-            await AudioJsInterop.PlayAsync(AudioElementRef);
-        }
-    }
-
     private void OnPlay(EventArgs args)
     {
         if (!PlayerService.IsPlaying)
@@ -103,16 +92,13 @@
 
     private async void OnPlayingChanged(bool play)
     {
-        if (!loadingUrl)
+        if (play)
         {
-            if (play)
-            {
-                await AudioJsInterop.PlayAsync(AudioElementRef);
-            }
-            else
-            {
-                await AudioJsInterop.PauseAsync(AudioElementRef);
-            }
+            await AudioJsInterop.PlayAsync(AudioElementRef);
+        }
+        else
+        {
+            await AudioJsInterop.PauseAsync(AudioElementRef);
         }
     }
 
@@ -122,7 +108,6 @@
         if (url != newValue)
         {
             url = newValue;
-            loadingUrl = true;
             AudioJsInterop.SetUri(url);
             await InvokeAsync(StateHasChanged);
         }


### PR DESCRIPTION
fixed audio over all platforms. oncanplay plays episode twice and loadingUrl doesnt load into iPhone by oncanplay method.

Issue: https://github.com/microsoft/dotnet-podcasts/issues/123