### PR TITLE
Add docker support for the Apple Silicon architecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,11 @@ The easiest way to get started is to build and run the .NET Podcasts app service
 docker-compose up
 ```
 
+- *For Apple arm64-based system*:
+```cli
+docker-compose -f docker-compose.arm64.yml -f docker-compose.override.yml up
+```
+
 This will deploy and start all services required to run the web, mobile, and desktop apps. The Web API will run on `localhost:5000` and the SignalR Hub for listen together will run on `localhost:5001`.
 
 ### Web, Mobile, & Desktop

--- a/docker-compose.arm64.yml
+++ b/docker-compose.arm64.yml
@@ -1,0 +1,53 @@
+version: '3.4'
+
+services:
+
+  podcast.api:
+    image: ${DOCKER_REGISTRY-}podcastapi
+    build:
+      context: .
+      dockerfile: src/Services/Podcasts/Podcast.API/Dockerfile
+    depends_on:
+      - podcast.db
+      - storage
+
+  podcast.updater.worker:
+    image: ${DOCKER_REGISTRY-}podcastupdaterworker
+    build:
+      context: .
+      dockerfile: src/Services/Podcasts/Podcast.Updater.Worker/Dockerfile
+    depends_on:
+      - podcast.db
+      - podcast.api
+      - storage
+
+  podcast.db:
+    image: mcr.microsoft.com/azure-sql-edge
+
+  listentogether.hub:
+    image: ${DOCKER_REGISTRY-}listentogetherhub
+    build:
+      context: .
+      dockerfile: src/Services/ListenTogether/ListenTogether.Hub/Dockerfile
+    depends_on:
+      - podcast.api
+
+  podcast.ingestion.worker:
+    image: ${DOCKER_REGISTRY-}podcastingestionworker
+    build:
+      context: .
+      dockerfile: src/Services/Podcasts/Podcast.Ingestion.Worker/Dockerfile
+    depends_on:
+      - podcast.db
+      - storage
+
+  podcast.web:
+    image: ${DOCKER_REGISTRY-}podcastweb
+    build:
+      context: .
+      dockerfile: src/Web/Server/Dockerfile
+    depends_on:
+      - podcast.api
+
+  storage:
+    image: mcr.microsoft.com/azure-storage/azurite:latest

--- a/docker-compose.dcproj
+++ b/docker-compose.dcproj
@@ -14,5 +14,6 @@
     </None>
     <None Include="docker-compose.yml" />
     <None Include=".dockerignore" />
+    <None Include="docker-compose.arm64.yml" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
As we don't have a Microsoft SQL Server docker image available yet to the Apple silicon (arm64), I added the *azure-sql-edge (arm64)* as a lightweight solution, on a specific docker-compose for this architecture.