### PR TITLE
[ci] updates for .NET 7 / maui builds

### DIFF
--- a/.github/workflows/podcast-mobile.yml
+++ b/.github/workflows/podcast-mobile.yml
@@ -27,7 +27,7 @@ jobs:
         run: |
           $ProgressPreference = 'SilentlyContinue'
           Invoke-WebRequest https://dot.net/v1/dotnet-install.ps1 -OutFile dotnet-install.ps1
-          .\dotnet-install.ps1 -Version 7.0.100-preview.6.22316.8 -InstallDir .
+          .\dotnet-install.ps1 -Channel 7.0.1xx -Quality preview -InstallDir .
 
       - name: install MAUI workload
         shell: pwsh


### PR DESCRIPTION
CI is failing with:

    Workload installation failed: Could not find workload 'microsoft-net-runtime-android-net6' extended by workload 'android' in manifest 'microsoft.net.sdk.android'

This is likely caused by using .NET 7 Preview 6.

Update the `dotnet-install` command to install the latest 7.0.1xx SDK.