### PR TITLE
Add endpoint names and setup Azure AD auth

### DIFF
--- a/src/Services/Podcasts/Podcast.MinimalAPI/Podcast.MinimalAPI.csproj
+++ b/src/Services/Podcasts/Podcast.MinimalAPI/Podcast.MinimalAPI.csproj
@@ -22,11 +22,11 @@
 		<PackageReference Include="Asp.Versioning.Http" Version="6.1.0" />
 		<PackageReference Include="Microsoft.OpenApi" Version="1.4.3" />
 		<PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="7.0.0-*" />
+		<PackageReference Include="Microsoft.Identity.Web" Version="1.25.3" />
 	</ItemGroup>
 
 	<ItemGroup>
 		<ProjectReference Include="..\Podcast.Infrastructure\Podcast.Infrastructure.csproj" />
-		<ProjectReference Include="..\Podcast.Ingestion.Worker\Podcast.Ingestion.Worker.csproj" />
 	</ItemGroup>
 
 </Project>

--- a/src/Services/Podcasts/Podcast.MinimalAPI/Program.cs
+++ b/src/Services/Podcasts/Podcast.MinimalAPI/Program.cs
@@ -9,6 +9,7 @@ using Microsoft.AspNetCore.RateLimiting;
 using System.Threading.RateLimiting;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Swashbuckle.AspNetCore.SwaggerGen;
+using Microsoft.Identity.Web;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -20,8 +21,8 @@ builder.Services.AddSingleton(new QueueClient(queueConnectionString, "feed-queue
 builder.Services.AddHttpClient<IFeedClient, FeedClient>();
 
 // Authentication and authorization-related services
-builder.Services.AddAuthentication().AddJwtBearer();
-builder.Services.AddAuthorization();
+builder.Services.AddMicrosoftIdentityWebApiAuthentication(builder.Configuration);
+builder.Services.AddAuthorizationBuilder().AddPolicy("modify_feeds", policy => policy.RequireScope("API.Access"));
 
 // OpenAPI and versioning-related services
 builder.Services.AddSwaggerGen();
@@ -60,7 +61,7 @@ await EnsureDbAsync(app.Services);
 app.UseSwagger();
 app.UseSwaggerUI(c =>
 {
-    c.SwaggerEndpoint("/swagger/v1/swagger.json", "NetPodcast Api v1");
+    c.SwaggerEndpoint("/swagger/v1/swagger.json", ".NET Podcasts Minimal API");
 });
 app.UseCors();
 app.UseRateLimiter();

--- a/src/Services/Podcasts/Podcast.MinimalAPI/Routes/CategoriesApi.cs
+++ b/src/Services/Podcasts/Podcast.MinimalAPI/Routes/CategoriesApi.cs
@@ -10,7 +10,7 @@ public static class CategoriesApi
 {
     public static RouteGroupBuilder MapCategoriesApi(this RouteGroupBuilder group)
     {
-        group.MapPost("/", GetAllCategories);
+        group.MapPost("/", GetAllCategories).WithName("GetCategories");
         return group;
     }
 

--- a/src/Services/Podcasts/Podcast.MinimalAPI/Routes/EpisodesApi.cs
+++ b/src/Services/Podcasts/Podcast.MinimalAPI/Routes/EpisodesApi.cs
@@ -10,7 +10,7 @@ public static class EpisodesApi
 {
     public static RouteGroupBuilder MapEpisodesApi(this RouteGroupBuilder group)
     {
-        group.MapPost("/{id}", GetEpisodeById);
+        group.MapPost("/{id}", GetEpisodeById).WithName("GetEpisodeById");
         return group;
     }
 

--- a/src/Services/Podcasts/Podcast.MinimalAPI/Routes/FeedsApi.cs
+++ b/src/Services/Podcasts/Podcast.MinimalAPI/Routes/FeedsApi.cs
@@ -14,10 +14,16 @@ public static class FeedsApi
 {
     public static RouteGroupBuilder MapFeedsApi(this RouteGroupBuilder group)
     {
-        group.MapPost("/", CreateFeed);
-        group.MapGet("/", GetAllFeeds);
-        group.MapPut("/{id}", UpdateFeed).RequireAuthorization().AddOpenApiSecurityRequirement();
-        group.MapDelete("/{id}", DeleteFeed).RequireAuthorization().AddOpenApiSecurityRequirement();
+        group.MapPost("/", CreateFeed).WithName("CreateFeed");
+        group.MapGet("/", GetAllFeeds).WithName("GetFeeds");
+        group.MapPut("/{id}", UpdateFeed)
+            .RequireAuthorization("modify_feeds")
+            .AddOpenApiSecurityRequirement()
+            .WithName("UpdateFeedById");
+        group.MapDelete("/{id}", DeleteFeed)
+            .RequireAuthorization("modify_feeds")
+            .AddOpenApiSecurityRequirement()
+            .WithName("DeleteFeedById");
         return group;
     }
 

--- a/src/Services/Podcasts/Podcast.MinimalAPI/Routes/ShowsApi.cs
+++ b/src/Services/Podcasts/Podcast.MinimalAPI/Routes/ShowsApi.cs
@@ -9,8 +9,8 @@ public static class ShowsApi
 {
     public static RouteGroupBuilder MapShowsApi(this RouteGroupBuilder group)
     {
-        group.MapGet("/", GetAllShows);
-        group.MapGet("/{id}", GetShowById);
+        group.MapGet("/", GetAllShows).WithName("GetShows");
+        group.MapGet("/{id}", GetShowById).WithName("GetShowsById");
         return group;
     }
 

--- a/src/Services/Podcasts/Podcast.MinimalAPI/appsettings.Development.json
+++ b/src/Services/Podcasts/Podcast.MinimalAPI/appsettings.Development.json
@@ -17,7 +17,8 @@
           "http://localhost:56906",
           "https://localhost:44385",
           "https://localhost:5001",
-          "http://localhost:5000"
+          "http://localhost:5000",
+          "1ba2c41d-3a54-414a-9700-1f9393cfafca"
         ],
         "ValidIssuer": "dotnet-user-jwts"
       }


### PR DESCRIPTION
Updates new minimal APIs app to:

- Configure Azure AD-based authentication
- Set endpoint names on all routes
- Update OpenAPI document title

cc: @baronfel Heads up as we'll need to update the deployment scripts to funnel through the Azure AD configuration.