### PR TITLE
Fix "Oops" Typo

### DIFF
--- a/src/Mobile/Resources/Strings/AppResource.Designer.cs
+++ b/src/Mobile/Resources/Strings/AppResource.Designer.cs
@@ -142,7 +142,7 @@ namespace Microsoft.NetConf2021.Maui.Resources.Strings {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Oppss.
+        ///   Looks up a localized string similar to Oops.
         /// </summary>
         internal static string Error_Title {
             get {

--- a/src/Mobile/Resources/Strings/AppResource.resx
+++ b/src/Mobile/Resources/Strings/AppResource.resx
@@ -145,7 +145,7 @@
     <value>Something went wrong</value>
   </data>
   <data name="Error_Title" xml:space="preserve">
-    <value>Oppss</value>
+    <value>Oops</value>
   </data>
   <data name="Home" xml:space="preserve">
     <value>Home</value>


### PR DESCRIPTION
<img width="329" alt="2022-12-13_23 23 54" src="https://user-images.githubusercontent.com/898335/207359017-83db35a4-774c-4cc8-8692-6b8d305a70d1.png">

Oops, we made a typo.