### PR TITLE
Removed a JitterHandler because of perf issue

### DIFF
--- a/src/Services/Podcasts/Podcast.API/Program.cs
+++ b/src/Services/Podcasts/Podcast.API/Program.cs
@@ -26,8 +26,7 @@ var queueConnectionString = builder.Configuration.GetConnectionString("FeedQueue
 
 builder.Services.AddSingleton(new QueueClient(queueConnectionString, "feed-queue"));
 builder.Services.AddHttpClient<IFeedClient, FeedClient>();
-builder.Services.AddTransient<JitterHandler>();
-builder.Services.AddHttpClient<ShowClient>().AddHttpMessageHandler<JitterHandler>();
+builder.Services.AddHttpClient<ShowClient>();
 
 // Authentication and authorization-related services
 // Comment back in if testing authentication

--- a/src/Services/Podcasts/Podcast.Infrastructure/Http/ShowClient.cs
+++ b/src/Services/Podcasts/Podcast.Infrastructure/Http/ShowClient.cs
@@ -4,32 +4,20 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
-namespace Podcast.Infrastructure.Http
+namespace Podcast.Infrastructure.Http;
+
+public class ShowClient
 {
-    public class JitterHandler : DelegatingHandler
+    private readonly HttpClient _httpClient;
+
+    public ShowClient(HttpClient httpClient)
     {
-        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
-        {
-            // Who would do such a thing?!
-            // TODO fix this horrible perf leak!
-            await Task.Delay(TimeSpan.FromMilliseconds(Random.Shared.NextInt64(50, 500)));
-            return await base.SendAsync(request, cancellationToken);
-        }
+        _httpClient = httpClient;
     }
 
-    public class ShowClient
+    public async Task<bool> CheckLink(string showLink)
     {
-        private readonly HttpClient _httpClient;
-
-        public ShowClient(HttpClient httpClient)
-        {
-            _httpClient = httpClient;
-        }
-
-        public async Task<bool> CheckLink(string showLink)
-        {
-            var response = await _httpClient.GetAsync(showLink, HttpCompletionOption.ResponseHeadersRead);
-            return response.IsSuccessStatusCode;
-        }
+        var response = await _httpClient.GetAsync(showLink, HttpCompletionOption.ResponseHeadersRead);
+        return response.IsSuccessStatusCode;
     }
 }


### PR DESCRIPTION
This is a PR that relates to an [issue opened by me](https://github.com/microsoft/dotnet-podcasts/issues/209).

Basically, for demo purposes, a delay is taking place before sending an HTTP request.
It was done for the logs to be seen clearly.

In this PR this part of the code is removed to optimize time processing.