### PR TITLE
Image Processing Service

### DIFF
--- a/src/Mobile/Microsoft.NetConf2021.Maui.csproj
+++ b/src/Mobile/Microsoft.NetConf2021.Maui.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.Razor">
+<Project Sdk="Microsoft.NET.Sdk.Razor">
 
   <PropertyGroup>
     <!-- iOS, Android, MacCatalyst -->
@@ -65,6 +65,8 @@
     <PackageReference Include="CommunityToolkit.Mvvm" Version="8.0.0" />
     <PackageReference Include="MonkeyCache.FileStore" Version="2.0.0-beta" />
     <PackageReference Include="Refractored.MvvmHelpers" Version="1.6.2" />
+    <PackageReference Include="SkiaSharp" Version="2.88.3" />
+    <PackageReference Include="System.Threading.RateLimiting" Version="7.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Mobile/Pages/EpisodeDetailPage.xaml
+++ b/src/Mobile/Pages/EpisodeDetailPage.xaml
@@ -20,7 +20,7 @@
                                  Spacing="8">
                 <Image Margin="0,4,0,8"
                        HeightRequest="156"
-                       Source="{Binding Image}"
+                       Source="{Binding Show.CachedImage, TargetNullValue='default_podcast_image.png'}"
                        SemanticProperties.Description="It is the banner of the episode"
                        WidthRequest="156" />
                 <Label Style="{StaticResource H6LabelStyle}"

--- a/src/Mobile/Pages/ShowDetailPage.xaml
+++ b/src/Mobile/Pages/ShowDetailPage.xaml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
+<?xml version="1.0" encoding="utf-8" ?>
 <ContentPage x:Class="Microsoft.NetConf2021.Maui.Pages.ShowDetailPage"
              xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
@@ -100,7 +100,7 @@
                            Grid.Row="0"
                            Grid.RowSpan="{OnIdiom Default=3, Phone=2}"
                            HeightRequest="{OnIdiom Default=230, Phone=156}"
-                           Source="{Binding Show.Image, FallbackValue=default_podcast_image.png}"
+                           Source="{Binding Show.CachedImage, TargetNullValue='default_podcast_image.png'}"
                            WidthRequest="{OnIdiom Default=230, Phone=156}" />
                     
                     <Label Grid.Column="1"

--- a/src/Mobile/Services/ImageProcessingService.cs
+++ b/src/Mobile/Services/ImageProcessingService.cs
@@ -1,0 +1,94 @@
+﻿using System;
+using System.Threading.RateLimiting;
+using Microsoft.Extensions.Logging;
+using SkiaSharp;
+
+namespace Microsoft.NetConf2021.Maui.Services;
+
+public class ImageProcessingService
+{
+    private readonly HttpClient httpClient = new HttpClient();
+
+    private readonly RateLimiter rateLimiter = new ConcurrencyLimiter(new ConcurrencyLimiterOptions { PermitLimit = 3, QueueProcessingOrder = QueueProcessingOrder.NewestFirst });
+
+    private readonly object cacheDirectoryLock = new object();
+
+    private readonly string imageCacheDirectory;
+
+    public ImageProcessingService()
+    {
+        imageCacheDirectory = Path.Combine(FileSystem.CacheDirectory, "remoteimages");
+    }
+
+    public async Task<string> ProcessRemoteImage(Uri imageUri, int maxHeight = 250, int maxWidth = 250, int quality = 75, SKEncodedImageFormat imageFormat = SKEncodedImageFormat.Png)
+    {
+        var imageUriHash = $"{Crc64.ComputeHashString(imageUri.ToString())}.{imageFormat}".ToLowerInvariant();
+
+        var cachedImagePath = Path.Combine(imageCacheDirectory, imageUriHash);
+
+        lock (cacheDirectoryLock)
+        {
+            if (!Directory.Exists(imageCacheDirectory))
+            {
+                Directory.CreateDirectory(imageCacheDirectory);
+            }
+        }
+
+        if (File.Exists(cachedImagePath))
+        {
+            return cachedImagePath;
+        }
+
+        RateLimitLease lease = rateLimiter.AttemptAcquire();
+
+        while (!lease.IsAcquired)
+        {
+            lease = await rateLimiter.AcquireAsync().ConfigureAwait(false);
+        }
+
+        SKBitmap bmp = null;
+
+        try
+        {
+            using var imageStream = await httpClient.GetStreamAsync(imageUri).ConfigureAwait(false);
+            using var data = SKData.Create(imageStream);
+            using var codec = SKCodec.Create(data);
+
+            var info = codec.Info;
+
+            var maxSize = Math.Max(maxHeight, maxWidth);
+
+            var supportedScale =
+                info.Height > info.Width
+                    ? (float)maxHeight / info.Height
+                    : (float)maxWidth / info.Width;
+
+            var scaledWidth = (int)(info.Width * supportedScale);
+            var scaledHeight = (int)(info.Height * supportedScale);
+
+            // decode the bitmap at the nearest size
+            var nearest = new SKImageInfo(scaledWidth, scaledHeight);
+
+            bmp = SKBitmap.Decode(codec);
+
+            SKImageInfo desired = new SKImageInfo(scaledWidth, scaledHeight);
+            bmp = bmp.Resize(desired, SKFilterQuality.High);
+
+            using var image = SKImage.FromBitmap(bmp);
+            using var encodedImage = image.Encode(imageFormat, quality);
+            using var encodedImageStream = encodedImage.AsStream();
+            using var file = File.Create(cachedImagePath);
+            await encodedImageStream.CopyToAsync(file).ConfigureAwait(false);
+        }
+        finally
+        {
+            bmp?.Dispose();
+            bmp = null;
+
+            lease.Dispose();
+        }
+
+        return cachedImagePath;
+    }
+}
+

--- a/src/Mobile/Services/ServicesExtensions.cs
+++ b/src/Mobile/Services/ServicesExtensions.cs
@@ -29,6 +29,8 @@ public static class ServicesExtensions
         builder.Services.AddScoped<ListenTogetherHubClient>(_ =>
             new ListenTogetherHubClient(Config.ListenTogetherUrl));
 
+        builder.Services.AddSingleton<ImageProcessingService>();
+
 
         return builder;
     }

--- a/src/Mobile/ViewModels/CategoryViewModel.cs
+++ b/src/Mobile/ViewModels/CategoryViewModel.cs
@@ -3,6 +3,9 @@
 [QueryProperty(nameof(Id), nameof(Id))]
 public partial class CategoryViewModel : ViewModelBase
 {
+    private readonly ShowsService showsService;
+    private readonly SubscriptionsService subscriptionsService;
+    private readonly ImageProcessingService imageProcessingService;
 
     [ObservableProperty]
     string text;
@@ -15,13 +18,12 @@ public partial class CategoryViewModel : ViewModelBase
     [ObservableProperty]
     List<ShowViewModel> shows;
 
-    readonly ShowsService showsService;
-    readonly SubscriptionsService subscriptionsService;
 
-    public CategoryViewModel(ShowsService shows, SubscriptionsService subs)
+    public CategoryViewModel(ShowsService shows, SubscriptionsService subs, ImageProcessingService imageProcessing)
     {
         showsService = shows;
         subscriptionsService = subs;
+        imageProcessingService = imageProcessing;
     }
 
 
@@ -63,7 +65,7 @@ public partial class CategoryViewModel : ViewModelBase
 
         foreach (var show in shows)
         {
-            var showVM = new ShowViewModel(show, subscriptionsService.IsSubscribed(show.Id));
+            var showVM = new ShowViewModel(show, subscriptionsService.IsSubscribed(show.Id), imageProcessingService);
             showList.Add(showVM);
         }
 

--- a/src/Mobile/ViewModels/DiscoverViewModel.cs
+++ b/src/Mobile/ViewModels/DiscoverViewModel.cs
@@ -5,9 +5,11 @@ namespace Microsoft.NetConf2021.Maui.ViewModels;
 
 public partial class DiscoverViewModel : ViewModelBase
 {
-    readonly ShowsService showsService;
-    readonly SubscriptionsService subscriptionsService;
-    IEnumerable<ShowViewModel> shows;
+    private readonly ShowsService showsService;
+    private readonly SubscriptionsService subscriptionsService;
+    private readonly ImageProcessingService imageProcessingService;
+
+    private IEnumerable<ShowViewModel> shows;
 
     [ObservableProperty]
     CategoriesViewModel categoriesVM;
@@ -18,10 +20,12 @@ public partial class DiscoverViewModel : ViewModelBase
     [ObservableProperty]
     ObservableRangeCollection<ShowGroup> podcastsGroup;
 
-    public DiscoverViewModel(ShowsService shows, SubscriptionsService subs, CategoriesViewModel categories)
+    public DiscoverViewModel(ShowsService shows, SubscriptionsService subs, CategoriesViewModel categories, ImageProcessingService imageProcessing)
     {
         showsService = shows;
         subscriptionsService = subs;
+        imageProcessingService = imageProcessing;
+
         PodcastsGroup = new ObservableRangeCollection<ShowGroup>();
         categoriesVM = categories;
     }
@@ -60,7 +64,7 @@ public partial class DiscoverViewModel : ViewModelBase
         var viewmodels = new List<ShowViewModel>();
         foreach (var show in shows)
         {
-            var showViewModel = new ShowViewModel(show, subscriptionsService.IsSubscribed(show.Id));
+            var showViewModel = new ShowViewModel(show, subscriptionsService.IsSubscribed(show.Id), imageProcessingService);
             viewmodels.Add(showViewModel);
         }
 

--- a/src/Mobile/ViewModels/ShowDetailViewModel.cs
+++ b/src/Mobile/ViewModels/ShowDetailViewModel.cs
@@ -1,19 +1,20 @@
 ﻿using Microsoft.NetConf2021.Maui.Resources.Strings;
 using MvvmHelpers;
-using MvvmHelpers.Interfaces;
 
 namespace Microsoft.NetConf2021.Maui.ViewModels;
 
 [QueryProperty(nameof(Id), nameof(Id))]
 public partial class ShowDetailViewModel : ViewModelBase
 {
-    public string Id { get; set; }
-    Guid showId;
+    private readonly PlayerService playerService;
+    private readonly SubscriptionsService subscriptionsService;
+    private readonly ListenLaterService listenLaterService;
+    private readonly ShowsService showsService;
+    private readonly ImageProcessingService imageProcessingService;
 
-    readonly PlayerService playerService;
-    readonly SubscriptionsService subscriptionsService;
-    readonly ListenLaterService listenLaterService;
-    readonly ShowsService showsService;
+    private Guid showId;
+
+    public string Id { get; set; }
 
     [ObservableProperty]
     ShowViewModel show;
@@ -24,20 +25,20 @@ public partial class ShowDetailViewModel : ViewModelBase
     [ObservableProperty]
     ObservableRangeCollection<Episode> episodes;
 
-
     [ObservableProperty]
     bool isPlaying;
 
     [ObservableProperty]
     string textToSearch;
 
-
-    public ShowDetailViewModel(ShowsService shows, PlayerService player, SubscriptionsService subs, ListenLaterService later)
+    public ShowDetailViewModel(ShowsService shows, PlayerService player, SubscriptionsService subs, ListenLaterService later, ImageProcessingService imageProcessing)
     {
         showsService = shows;
         playerService = player;
         subscriptionsService = subs;
         listenLaterService = later;
+        imageProcessingService = imageProcessing;
+
         episodes = new ObservableRangeCollection<Episode>();
     }
 
@@ -65,9 +66,10 @@ public partial class ShowDetailViewModel : ViewModelBase
             return;
         }
 
-        var showVM = new ShowViewModel(show, subscriptionsService.IsSubscribed(show.Id));
+        var showVM = new ShowViewModel(show, subscriptionsService.IsSubscribed(show.Id), imageProcessingService);
 
         Show = showVM;
+        Show.InitializeCommand.Execute(null);
         Episodes.ReplaceRange(show.Episodes.ToList());
     }
 

--- a/src/Mobile/ViewModels/ShowViewModel.cs
+++ b/src/Mobile/ViewModels/ShowViewModel.cs
@@ -2,14 +2,19 @@
 
 public partial class ShowViewModel : ObservableObject
 {
+    private readonly ImageProcessingService imageProcessingService;
+
+    bool isInitialized;
+
     public Show Show { get; set; }
 
     [ObservableProperty]
     bool isSubscribed;
 
-    public IEnumerable<Episode> Episodes => Show?.Episodes;
+    [ObservableProperty]
+    string cachedImage;
 
-    public Uri Image => Show?.Image;
+    public IEnumerable<Episode> Episodes => Show?.Episodes;
 
     public string Author => Show?.Author;
 
@@ -17,12 +22,33 @@ public partial class ShowViewModel : ObservableObject
 
     public string Description => Show?.Description;
 
-    public ShowViewModel(Show show, bool isSubscribed)
+    public ShowViewModel(Show show, bool isSubscribed, ImageProcessingService imageProcessing)
     {
         Show = show;
         IsSubscribed = isSubscribed;
+        imageProcessingService = imageProcessing;
     }
 
     [RelayCommand]
-    Task NavigateToDetail() => Shell.Current.GoToAsync($"{nameof(ShowDetailPage)}?Id={Show.Id}");
+    private Task NavigateToDetail() => Shell.Current.GoToAsync($"{nameof(ShowDetailPage)}?Id={Show.Id}");
+
+    [RelayCommand]
+    private async Task InitializeAsync()
+    {
+        if (isInitialized)
+        {
+            return;
+        }
+
+        try
+        {
+            CachedImage = await imageProcessingService.ProcessRemoteImage(Show.Image);
+        }
+        catch
+        {
+            return;
+        }
+
+        isInitialized = true;
+    }
 }

--- a/src/Mobile/ViewModels/SubscriptionsViewModel.cs
+++ b/src/Mobile/ViewModels/SubscriptionsViewModel.cs
@@ -4,15 +4,16 @@ namespace Microsoft.NetConf2021.Maui.ViewModels;
 
 public partial class SubscriptionsViewModel : ViewModelBase
 {
-    readonly SubscriptionsService subscriptionsService;
+    private readonly SubscriptionsService subscriptionsService;
+    private readonly ImageProcessingService imageProcessingService;
 
     [ObservableProperty]
     ObservableRangeCollection<ShowViewModel> subscribedShows;
 
-
-    public SubscriptionsViewModel(SubscriptionsService subs)
+    public SubscriptionsViewModel(SubscriptionsService subs, ImageProcessingService imageProcessing)
     {
         subscriptionsService = subs;
+        imageProcessingService = imageProcessing;
         SubscribedShows = new ObservableRangeCollection<ShowViewModel>();
     }
 
@@ -23,7 +24,7 @@ public partial class SubscriptionsViewModel : ViewModelBase
         var list = new List<ShowViewModel>();
         foreach (var show in shows)
         {
-            var showViewModel = new ShowViewModel(show, subscriptionsService.IsSubscribed(show.Id));
+            var showViewModel = new ShowViewModel(show, subscriptionsService.IsSubscribed(show.Id), imageProcessingService);
             list.Add(showViewModel);
         }
         SubscribedShows.ReplaceRange(list);

--- a/src/Mobile/Views/ShowItemView.xaml
+++ b/src/Mobile/Views/ShowItemView.xaml
@@ -1,49 +1,62 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
-<VerticalStackLayout  xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+<Grid  xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
                       xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
                       x:Class="Microsoft.NetConf2021.Maui.Views.ShowItemView"
                       xmlns:viewmodels="clr-namespace:Microsoft.NetConf2021.Maui.ViewModels"
+                      xmlns:views="clr-namespace:Microsoft.NetConf2021.Maui.Views"
                       x:DataType="viewmodels:ShowViewModel"
-                      x:Name="self"
-                      >
-    <VerticalStackLayout.GestureRecognizers>
+                      x:Name="self">
+    <Grid.GestureRecognizers>
         <TapGestureRecognizer Command="{Binding NavigateToDetailCommand}" />
-    </VerticalStackLayout.GestureRecognizers>
-    <Grid>
-        <ActivityIndicator WidthRequest="50" HeightRequest="50" IsRunning="{Binding IsLoading, Source={x:Reference self}}"/>
+    </Grid.GestureRecognizers>
+    <Grid.RowDefinitions>
+        <RowDefinition Height="*" />
+        <RowDefinition Height="32" />
+        <RowDefinition Height="28" />
+    </Grid.RowDefinitions>
 
-        <Image Aspect="AspectFit"
-               MinimumWidthRequest="{x:OnIdiom Phone=180, Default=264}"
-               MinimumHeightRequest="{x:OnIdiom Default=264, Phone=180}"
-               MaximumHeightRequest="{x:OnIdiom Phone=190, Default=264}"
-               MaximumWidthRequest="{x:OnIdiom Phone=190, Default=264}"
-               Source="{Binding Show.Image}"
-               Loaded="Image_Loaded"
-               HorizontalOptions="Start"
-               Margin="0,0,0,12" />
+    <Image Aspect="AspectFit"
+            MinimumWidthRequest="{x:OnIdiom Phone=180, Default=264}"
+            MinimumHeightRequest="{x:OnIdiom Default=264, Phone=180}"
+            MaximumHeightRequest="{x:OnIdiom Phone=190, Default=264}"
+            MaximumWidthRequest="{x:OnIdiom Phone=190, Default=264}"
+            Source="{Binding CachedImage, TargetNullValue='default_podcast_image.png'}"
+            HorizontalOptions="Center"
+            Margin="0,0,0,12"
+            Grid.Row="0" Grid.Column="0"/>
 
-        <Image Source="suscribed.png"
-               HorizontalOptions="End"
-               VerticalOptions="End"
-               SemanticProperties.Description="Suscribed icon"
-               Margin="22"
-               IsVisible="{Binding IsSubscribed}"
-               WidthRequest="24"
-               HeightRequest="24">
-            <Image.GestureRecognizers>
-                <TapGestureRecognizer Command="{Binding SubscriptionCommand, Source={x:Reference self}}" CommandParameter="{Binding }"/>
-            </Image.GestureRecognizers>
-        </Image>
-    </Grid>
-    <Label Text="{Binding Show.Title}"
+    <Image Source="suscribed.png"
+            HorizontalOptions="End"
+            VerticalOptions="End"
+            SemanticProperties.Description="Suscribed icon"
+            Margin="22"
+            IsVisible="{Binding IsSubscribed}"
+            WidthRequest="24"
+            HeightRequest="24"
+            Grid.Row="0" Grid.Column="0">
+        <Image.GestureRecognizers>
+            <TapGestureRecognizer Command="{Binding SubscriptionCommand, Source={x:Reference self}}" CommandParameter="{Binding }"/>
+        </Image.GestureRecognizers>
+    </Image>
+
+    <ActivityIndicator
+        InputTransparent="True"
+        HorizontalOptions="Center" VerticalOptions="Center"
+        WidthRequest="50" HeightRequest="50"
+        IsRunning="{Binding InitializeCommand.IsRunning}"
+        Grid.Row="0" Grid.Column="0"/>
+
+    <Label Text="{Binding Title}"
            MaxLines="1"
            HorizontalOptions="Start"
            LineBreakMode="TailTruncation"
            MaximumWidthRequest="{x:OnIdiom Phone=190, Default=264}"
-           Style="{OnIdiom Default={StaticResource BodyXLLabelStyle},Phone={StaticResource BodyLLabelStyle}}" />
-    <Label Text="{Binding Show.Author}"
+           Style="{OnIdiom Default={StaticResource BodyXLLabelStyle},Phone={StaticResource BodyLLabelStyle}}"
+           Grid.Row="1" Grid.Column="0"/>
+    <Label Text="{Binding Author}"
            LineBreakMode="TailTruncation"
            MaxLines="1"
-           Style="{OnIdiom Default={StaticResource BodyMLabelStyle},Phone={StaticResource BodySLabelStyle}}" />
-</VerticalStackLayout>
+           Style="{OnIdiom Default={StaticResource BodyMLabelStyle},Phone={StaticResource BodySLabelStyle}}"
+           Grid.Row="2" Grid.Column="0"/>
+</Grid>
 

--- a/src/Mobile/Views/ShowItemView.xaml.cs
+++ b/src/Mobile/Views/ShowItemView.xaml.cs
@@ -16,13 +16,6 @@ public partial class ShowItemView
             typeof(ShowItemView),
             default(ShowViewModel));
 
-    public static readonly BindableProperty IsLoadingProperty =
-        BindableProperty.Create(
-            nameof(IsLoading),
-            typeof(bool),
-            typeof(ShowItemView),
-            true);
-
     public ICommand SubscriptionCommand
     {
         get { return (ICommand)GetValue(SubscriptionCommandProperty); }
@@ -35,24 +28,21 @@ public partial class ShowItemView
         set { SetValue(SubscriptionCommandParameterProperty, value); }
     }
 
-    public bool IsLoading
-    {
-        get { return (bool)GetValue(IsLoadingProperty); }
-        set { SetValue(IsLoadingProperty, value); }
-    }
-
     public ShowItemView()
     {
         InitializeComponent();
     }
 
-    private void Image_Loaded(object sender, EventArgs e)
+    protected override void OnBindingContextChanged()
     {
-        Task.Run(async () =>
+        base.OnBindingContextChanged();
+
+        if(BindingContext is not ShowViewModel vm)
         {
-            await Task.Delay(2000);
-            IsLoading = false;
-        });
+            return;
+        }
+
+        vm.InitializeCommand.Execute(null);
     }
 }
 


### PR DESCRIPTION
This is to help with further image compression and resizing for better overall performance.

Some of the images for the podcasts are quite large (around 3000x3000). The introduced service will resize the images to roughly 250x250 and perform additional compression (80%) of the original. This results in far better scrolling and loading performance.