### PR TITLE
Fix .NET 8 build errors

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -6,11 +6,8 @@
   <packageSources>
     <clear />
     <!-- Don't add nuget.org as a feed. If a new package is needed, it should be mirrored to the dotnet-public feed. -->
-    <add key="dotnet6" value="https://aka.ms/dotnet6/nuget/index.json" />
-    <add key="dotnet7" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet7/nuget/v3/index.json" />
+    <add key="dotnet8" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet8/nuget/v3/index.json" />
     <add key="dotnet-public" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json" />
-    <add key="darc-pub-dotnet-runtime-cd2d837" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-runtime-cd2d8379/nuget/v3/index.json" />
-    <add key="darc-pub-dotnet-aspnetcore-681a0ac7" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/darc-pub-dotnet-aspnetcore-681a0ac7/nuget/v3/index.json" />
   </packageSources>
   <disabledPackageSources>
     <clear />

--- a/src/Mobile/Blazor/ListenTogetherComponent.razor
+++ b/src/Mobile/Blazor/ListenTogetherComponent.razor
@@ -1,5 +1,6 @@
 ﻿@implements IDisposable
 @using Podcast.Components.ListenTogether
+@using CommunityToolkit.Mvvm.Messaging
 @using static Podcast.Components.ListenTogether.ListenTogether
 @inject ThemeInterop ThemeInterop
 @inject PlayerService PlayerService
@@ -22,17 +23,17 @@
 
 	protected override void OnInitialized()
 	{
-		MessagingCenter.Instance.Subscribe<string>(
+		WeakReferenceMessenger.Default.Register<object, string>(
 			".NET Pods",
 			"ChangeWebTheme",
-			async (sender) =>
+			async (_, __) =>
 				{
 					await UpdateWebThemeAsync();
 				});
-		MessagingCenter.Instance.Subscribe<string>(
+		WeakReferenceMessenger.Default.Register<object, string>(
 			".NET Pods",
 			"LeaveRoom",
-			async (sender) =>
+			async (_, __) =>
 				{
 					LeaveRoom();
 					await InvokeAsync(StateHasChanged);
@@ -54,8 +55,8 @@
 	{
 		PlayerService.IsPlayingChanged -= IsLocalPlayingChanged;
 		PlayerService.NewEpisodeAdded -= NewEpisodeAddedToPlayer;
-		MessagingCenter.Instance.Unsubscribe<string>(".NET Pods", "ChangeWebTheme");
-		MessagingCenter.Instance.Unsubscribe<string>(".NET Pods", "LeaveRoom");
+		WeakReferenceMessenger.Default.Unregister<string, string>(".NET Pods", "ChangeWebTheme");
+		WeakReferenceMessenger.Default.Unregister<string, string>(".NET Pods", "LeaveRoom");
 	}
 
 	private void JoinRoom(string roomCode)

--- a/src/Mobile/Helpers/TheTheme.cs
+++ b/src/Mobile/Helpers/TheTheme.cs
@@ -1,4 +1,6 @@
-﻿namespace Microsoft.NetConf2021.Maui.Helpers;
+﻿using CommunityToolkit.Mvvm.Messaging;
+
+namespace Microsoft.NetConf2021.Maui.Helpers;
 
 public static class TheTheme
 {
@@ -16,6 +18,6 @@ public static class TheTheme
 
         }
 
-        MessagingCenter.Instance.Send<string>(".NET Pods", "ChangeWebTheme");
+        WeakReferenceMessenger.Default.Send<string, string>(".NET Pods", "ChangeWebTheme");
     }
 }

--- a/src/Mobile/Microsoft.NetConf2021.Maui.csproj
+++ b/src/Mobile/Microsoft.NetConf2021.Maui.csproj
@@ -51,6 +51,7 @@
   <ItemGroup>
     <PackageReference Include="MonkeyCache.FileStore" Version="2.0.0-beta" />
     <PackageReference Include="Refractored.MvvmHelpers" Version="1.6.2" />
+    <PackageReference Include="CommunityToolkit.Mvvm" Version="8.1.0" />
   </ItemGroup>
 
 

--- a/src/Mobile/Pages/ListenTogetherPage.xaml.cs
+++ b/src/Mobile/Pages/ListenTogetherPage.xaml.cs
@@ -1,4 +1,5 @@
-﻿
+﻿using CommunityToolkit.Mvvm.Messaging;
+
 namespace Microsoft.NetConf2021.Maui.Pages
 {
     public partial class ListenTogetherPage
@@ -17,7 +18,7 @@ namespace Microsoft.NetConf2021.Maui.Pages
         protected override void OnDisappearing()
         {
             player.OnDisappearing();
-            MessagingCenter.Instance.Send<string>(".NET Pods", "LeaveRoom");
+            WeakReferenceMessenger.Default.Send<string, string>(".NET Pods", "LeaveRoom");
             base.OnDisappearing();
         }
     }

--- a/src/Mobile/ViewModels/ShowDetailViewModel.cs
+++ b/src/Mobile/ViewModels/ShowDetailViewModel.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.NetConf2021.Maui.Resources.Strings;
+﻿using CommunityToolkit.Mvvm.Messaging;
+using Microsoft.NetConf2021.Maui.Resources.Strings;
 
 namespace Microsoft.NetConf2021.Maui.ViewModels
 {
@@ -72,7 +73,7 @@ namespace Microsoft.NetConf2021.Maui.ViewModels
             subscriptionsService = subs;
             listenLaterService = later;
 
-            MessagingCenter.Instance.Subscribe<string>(".NET Pods", "UnSubscribe", async (sender) =>
+            WeakReferenceMessenger.Default.Register<string, string>(".NET Pods", "UnSubscribe", async (_, __) =>
             {
                 await Show.InitializeAsync();
 

--- a/src/Mobile/ViewModels/SubscriptionsViewModel.cs
+++ b/src/Mobile/ViewModels/SubscriptionsViewModel.cs
@@ -1,4 +1,6 @@
-﻿namespace Microsoft.NetConf2021.Maui.ViewModels;
+﻿using CommunityToolkit.Mvvm.Messaging;
+
+namespace Microsoft.NetConf2021.Maui.ViewModels;
 
 public class SubscriptionsViewModel : BaseViewModel
 {
@@ -59,7 +61,7 @@ public class SubscriptionsViewModel : BaseViewModel
         {
             await subscriptionsService.UnSubscribeFromShowAsync(vm.Show); 
             SubscribedShows.Remove(podcastToRemove);
-            MessagingCenter.Instance.Send<string>(".NET Pods", "UnSubscribe");
+            WeakReferenceMessenger.Default.Send<string, string>(".NET Pods", "UnSubscribe");
         }
     }
 }


### PR DESCRIPTION
Context: https://github.com/dotnet/maui/pull/12885/files

The main breaking change is that `MessagingCenter` is now `internal` / in the process of being removed.

Migrate to the messenger in the Community Toolkit instead.

I also updated the `NuGet.config` for the dotnet8 feed.