### PR TITLE
Added missing provider registration required for azure deployment

### DIFF
--- a/docs/deploy-websites-services.md
+++ b/docs/deploy-websites-services.md
@@ -50,6 +50,12 @@ Run the following command to ensure the following dependencies
 az provider register --namespace Microsoft.ContainerRegistry
 ```
 
+and
+
+```console
+az provider register --namespace Microsoft.Storage
+```
+
 and also Microsoft.App
 
 ```console


### PR DESCRIPTION
Without adding this provider we hit an error.
Having it here will help others add it ahead of time without having to wait for the action to fail