### PR TITLE
[net8.0] fix C# compiler error involving `x:Name`

### DIFF
--- a/.github/workflows/podcast-mobile.yml
+++ b/.github/workflows/podcast-mobile.yml
@@ -28,14 +28,10 @@ jobs:
           dotnet-version: 8.0.x
 
       - name: install MAUI workload
-        shell: pwsh
-        run: |
-          & .\dotnet workload install maui
+        run: dotnet workload install maui
 
       - name: build Microsoft.NetConf2021.Maui.csproj
-        shell: pwsh
-        run: |
-          & .\dotnet build src/Mobile/Microsoft.NetConf2021.Maui.csproj -bl:mobile.binlog
+        run: dotnet build src/Mobile/Microsoft.NetConf2021.Maui.csproj -bl:mobile.binlog
 
       - name: archive logs
         if: always()

--- a/.github/workflows/podcast-mobile.yml
+++ b/.github/workflows/podcast-mobile.yml
@@ -34,7 +34,7 @@ jobs:
         run: |
           $ProgressPreference = 'SilentlyContinue'
           Invoke-WebRequest https://raw.githubusercontent.com/dotnet/maui/net8.0/NuGet.config -OutFile maui-main-NuGet.config
-          & .\dotnet workload install maui wasi-experimental --from-rollback-file https://aka.ms/dotnet/maui/net8.0.json --configfile maui-main-NuGet.config
+          & .\dotnet workload install maui --from-rollback-file https://aka.ms/dotnet/maui/net8.0.json --configfile maui-main-NuGet.config
 
       - name: build Microsoft.NetConf2021.Maui.csproj
         shell: pwsh

--- a/.github/workflows/podcast-mobile.yml
+++ b/.github/workflows/podcast-mobile.yml
@@ -34,7 +34,7 @@ jobs:
         run: |
           $ProgressPreference = 'SilentlyContinue'
           Invoke-WebRequest https://raw.githubusercontent.com/dotnet/maui/net8.0/NuGet.config -OutFile maui-main-NuGet.config
-          & .\dotnet workload install maui --from-rollback-file https://aka.ms/dotnet/maui/net8.0.json --configfile maui-main-NuGet.config
+          & .\dotnet workload install maui wasi-experimental --from-rollback-file https://aka.ms/dotnet/maui/net8.0.json --configfile maui-main-NuGet.config
 
       - name: build Microsoft.NetConf2021.Maui.csproj
         shell: pwsh

--- a/.github/workflows/podcast-mobile.yml
+++ b/.github/workflows/podcast-mobile.yml
@@ -23,18 +23,14 @@ jobs:
       - uses: actions/checkout@v2
 
       - name: install .NET
-        shell: pwsh
-        run: |
-          $ProgressPreference = 'SilentlyContinue'
-          Invoke-WebRequest https://dot.net/v1/dotnet-install.ps1 -OutFile dotnet-install.ps1
-          .\dotnet-install.ps1 -Channel 8.0 -Quality daily -InstallDir .
+        uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: 8.0.x
 
       - name: install MAUI workload
         shell: pwsh
         run: |
-          $ProgressPreference = 'SilentlyContinue'
-          Invoke-WebRequest https://raw.githubusercontent.com/dotnet/maui/net8.0/NuGet.config -OutFile maui-main-NuGet.config
-          & .\dotnet workload install maui --from-rollback-file https://aka.ms/dotnet/maui/net8.0.json --configfile maui-main-NuGet.config
+          & .\dotnet workload install maui
 
       - name: build Microsoft.NetConf2021.Maui.csproj
         shell: pwsh

--- a/NuGet.config
+++ b/NuGet.config
@@ -5,9 +5,9 @@
   </fallbackPackageFolders>
   <packageSources>
     <clear />
-    <!-- Don't add nuget.org as a feed. If a new package is needed, it should be mirrored to the dotnet-public feed. -->
-    <add key="dotnet8" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet8/nuget/v3/index.json" />
-    <add key="dotnet-public" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json" />
+    <!-- If a second feed is needed here, switch to dotnet-public feed. -->
+    <add key="nuget" value="https://api.nuget.org/v3/index.json" />
+    <!-- <add key="dotnet-public" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json" /> -->
   </packageSources>
   <disabledPackageSources>
     <clear />

--- a/src/Mobile/Controls/HeaderControl.xaml
+++ b/src/Mobile/Controls/HeaderControl.xaml
@@ -6,7 +6,7 @@
     <ContentView.Content>
         <ContentView>
             <OnPlatform x:TypeArguments="View">
-                <On Platform="UWP, macOS">
+                <On Platform="UWP, MacCatalyst">
                     <Grid RowDefinitions="*, auto">
                         <SearchBar x:Name="searchBar"
                                    HorizontalOptions="Start"

--- a/src/Mobile/Controls/Player.xaml
+++ b/src/Mobile/Controls/Player.xaml
@@ -10,7 +10,7 @@
     <ContentView.HeightRequest>
         <OnPlatform x:TypeArguments="x:Double">
             <On Platform="Android,iOS">70</On>
-            <On Platform="UWP,macOS">90</On>
+            <On Platform="UWP,MacCatalyst">90</On>
         </OnPlatform>
     </ContentView.HeightRequest>
 
@@ -42,7 +42,7 @@
 
                 </Grid>
             </On>
-            <On Platform="UWP, macOS">
+            <On Platform="UWP, MacCatalyst">
                 <Grid ColumnDefinitions="auto, *, auto">
                     <Grid ColumnDefinitions="auto, auto"
                           RowDefinitions="auto,auto"

--- a/src/Mobile/Controls/Player.xaml.cs
+++ b/src/Mobile/Controls/Player.xaml.cs
@@ -51,8 +51,10 @@ public partial class Player : ContentView
         epiosdeTitle.Text = this.playerService.CurrentEpisode.Title;
         authorText.Text = $"{this.playerService.CurrentShow?.Author} - {this.playerService.CurrentEpisode?.Published.ToString("MMM, d yyy")}";
 
+#if WINDOWS || MACCATALYST
         podcastImage.Source = this.playerService.CurrentShow?.Image;
         duration.Text = this.playerService.CurrentEpisode?.Duration.ToString();
+#endif
     }
 
     private void PlayerService_IsPlayingChanged(object sender, EventArgs e)

--- a/src/Mobile/Controls/Player.xaml.cs
+++ b/src/Mobile/Controls/Player.xaml.cs
@@ -46,12 +46,12 @@ public partial class Player : ContentView
     {
         this.IsVisible = true;
 
+#if ANDROID || IOS
         this.playButton.Source = this.playerService.IsPlaying ? "player_pause.png" : "player_play.png";
 
         epiosdeTitle.Text = this.playerService.CurrentEpisode.Title;
         authorText.Text = $"{this.playerService.CurrentShow?.Author} - {this.playerService.CurrentEpisode?.Published.ToString("MMM, d yyy")}";
-
-#if WINDOWS || MACCATALYST
+#else
         podcastImage.Source = this.playerService.CurrentShow?.Image;
         duration.Text = this.playerService.CurrentEpisode?.Duration.ToString();
 #endif

--- a/src/Mobile/Pages/ShowDetailPage.xaml
+++ b/src/Mobile/Pages/ShowDetailPage.xaml
@@ -69,7 +69,7 @@
                             <ImageButton.IsVisible>
                                 <OnPlatform x:TypeArguments="x:Boolean">
                                     <On Platform="Android,iOS">false</On>
-                                    <On Platform="UWP,macOS">true</On>
+                                    <On Platform="UWP,MacCatalyst">true</On>
                                 </OnPlatform>
                             </ImageButton.IsVisible>
                             <ImageButton.Triggers>


### PR DESCRIPTION
Context: https://github.com/dotnet/maui/pull/5611
Fixes: https://github.com/microsoft/dotnet-podcasts/issues/239

The `net8.0` branch currently fails to build with:

    src/Mobile/Controls/Player.xaml.cs(54,9): error CS0103: The name 'podcastImage' does not exist in the current context
    src/Mobile/Controls/Player.xaml.cs(55,9): error CS0103: The name 'duration' does not exist in the current context

We think that `x:Name` in .NET 8 appropriately "skips" emitting fields when used in combination with `<OnPlatform/>`.

We can condition the C# code accessing these files with `#if WINDOWS || MACCATALYST` to solve this.

There are also a lot places using `<On Platform="UWP, macOS">`, we could consider cleaning these up in a future PR.